### PR TITLE
fix data parsing in iter_line()

### DIFF
--- a/tap_referral_saasquatch/__init__.py
+++ b/tap_referral_saasquatch/__init__.py
@@ -122,11 +122,11 @@ def stream_export(entity, export_id):
 
     return rows
 
-    # This funcitoin is derived from 
-    # https://github.com/requests/requests/blob/9c6bd54b44c0b05c6907522e8d9998a87b69c1cd/requests/models.py#L782
-    # Note: when the requests 3.0 is released, we could simply use their build-in Response.iter_lines() function,
-    # and this function could be removed.
-    
+# This funcitoin is derived from 
+# https://github.com/requests/requests/blob/9c6bd54b44c0b05c6907522e8d9998a87b69c1cd/requests/models.py#L782
+# Note: when the requests 3.0 is released, we could simply use their
+# build-in Response.iter_lines() function,and this function could be
+# removed.
 def iter_lines(response, chunk_size=requests.models.ITER_CHUNK_SIZE, decode_unicode=None, delimiter=None):
     """Iterates over the response data, one line at a time.  When
         stream=True is set on the request, this avoids reading the

--- a/tap_referral_saasquatch/__init__.py
+++ b/tap_referral_saasquatch/__init__.py
@@ -122,11 +122,11 @@ def stream_export(entity, export_id):
 
     return rows
 
-"""This funcitoin is derived from 
-    https://github.com/requests/requests/blob/9c6bd54b44c0b05c6907522e8d9998a87b69c1cd/requests/models.py#L782
-    Note: when the requests 3.0 is released, we could simply use their build-in Response.iter_lines() function,
-    and this function could be removed.
-    """
+    # This funcitoin is derived from 
+    # https://github.com/requests/requests/blob/9c6bd54b44c0b05c6907522e8d9998a87b69c1cd/requests/models.py#L782
+    # Note: when the requests 3.0 is released, we could simply use their build-in Response.iter_lines() function,
+    # and this function could be removed.
+    
 def iter_lines(response, chunk_size=requests.models.ITER_CHUNK_SIZE, decode_unicode=None, delimiter=None):
     """Iterates over the response data, one line at a time.  When
         stream=True is set on the request, this avoids reading the

--- a/tap_referral_saasquatch/__init__.py
+++ b/tap_referral_saasquatch/__init__.py
@@ -122,12 +122,12 @@ def stream_export(entity, export_id):
 
     return rows
 
+"""This funcitoin is derived from 
+    https://github.com/requests/requests/blob/9c6bd54b44c0b05c6907522e8d9998a87b69c1cd/requests/models.py#L782
+    Note: when the requests 3.0 is released, we could simply use their build-in Response.iter_lines() function,
+    and this function could be removed.
+    """
 def iter_lines(response, chunk_size=requests.models.ITER_CHUNK_SIZE, decode_unicode=None, delimiter=None):
-    """This funcitoin is derived from 
-        https://github.com/requests/requests/blob/9c6bd54b44c0b05c6907522e8d9998a87b69c1cd/requests/models.py#L782
-        Note: when the requests 3.0 is released, we could simply use their build-in Response.iter_lines() function,
-        and this function could be removed.
-        """
     """Iterates over the response data, one line at a time.  When
         stream=True is set on the request, this avoids reading the
         content at once into memory for large responses.
@@ -205,7 +205,7 @@ def transform_timestamp(value):
     if not value:
         return None
 
-    return utils.strftime(datetime.datetime.utcfromtimestamp(int(value) * 0.001).replace(tzinfo=pytz.utc))
+    return utils.strftime(datetime.datetime.fromtimestamp(int(value) * 0.001, tz=pytz.utc))
 
 
 TRANSFORMS = {
@@ -243,7 +243,7 @@ def sync_entity(entity, key_properties):
     logger.info("{}: Sent schema".format(entity))
 
     logger.info("{}: Requesting export".format(entity))
-    export_start = utils.strftime(datetime.datetime.utcnow().replace(tzinfo=pytz.utc))
+    export_start = utils.strftime(utils.now())
     export_id = request_export(entity)
 
     logger.info("{}: Export ready".format(entity))


### PR DESCRIPTION
There is an issue with iter_line() function imported from requests library, which occasionally split the delimiter into two chunks so the data is parsed incorrectly and a blank entities in our record will be generated. 
This fix refers to https://github.com/requests/requests/pull/3984/files/458df8f4f432956003a81a5285129e6dbf9b40b0 which is an internal fix from the library party but hasn't been released with the latest version yet. Our fix here simply grab their fix from github and place them in our script locally.